### PR TITLE
[patch] Ensure CASE bundle scripts are executable

### DIFF
--- a/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
@@ -37,7 +37,13 @@
       - "Registry Public Host ................... {{ registry_public_host }}"
 
 
-# 3. Set up Authentication for ICR
+# 3. Ensure *.sh files in the case bundle are executable
+# -----------------------------------------------------------------------------
+- name: "Make all CASE bundle shell scripts executable"
+  shell: chmod u+x {{ case_bundle_dir }}/case/{{ case_name }}/inventory/{{ case_inventory_name }}/files/*.sh
+
+
+# 4. Set up Authentication for ICR
 # -----------------------------------------------------------------------------
 # TODO: For now this is limited to unauthenticed registry (like the one set up by the "registry" role)
 
@@ -51,7 +57,7 @@
   register: configureCredsResult
 
 
-# 4. Perform a Dry Run
+# 5. Perform a Dry Run
 # -----------------------------------------------------------------------------
 # Perform a dry run first, if it fails it will report why and nothing will be changed om the target system
 - name: "Mirror Images Dry Run ({{ case_bundle_dir }}/case/{{ case_name }})"
@@ -71,7 +77,7 @@
     msg: "{{ dryrun_result.stdout_lines }}"
 
 
-# 5. Execute the Mirror
+# 6. Execute the Mirror
 # -----------------------------------------------------------------------------
 - name: Mirror Images
   when: not mirror_dry_run_only


### PR DESCRIPTION
Some CASE bundles contain scripts that are not executable, a simple step in the `case_mirror` role has been added to `chmod u+x` all `*.sh` files in the CASE setup inventory.