### PR TITLE
[patch] Use skopeo for image mirroring

### DIFF
--- a/ibm/mas_airgap/playbooks/mirror_common_services.yml
+++ b/ibm/mas_airgap/playbooks/mirror_common_services.yml
@@ -19,8 +19,6 @@
     case_inventory_name: "ibmCommonServiceOperatorSetup"
     registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
 
-    mirror_dry_run_only: false
-
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
     - name: Check for required environment variables

--- a/ibm/mas_airgap/playbooks/mirror_mas_core.yml
+++ b/ibm/mas_airgap/playbooks/mirror_mas_core.yml
@@ -18,8 +18,6 @@
     case_inventory_name: "ibmMasSetup"
     registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
 
-    mirror_dry_run_only: false
-
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
     - name: Check for required environment variables

--- a/ibm/mas_airgap/playbooks/mirror_sls.yml
+++ b/ibm/mas_airgap/playbooks/mirror_sls.yml
@@ -8,8 +8,6 @@
     case_inventory_name: "ibmSlsSetup"
     registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
 
-    mirror_dry_run_only: false
-
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
     - name: Check for required environment variables

--- a/ibm/mas_airgap/roles/case_mirror/defaults/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/defaults/main.yml
@@ -9,5 +9,3 @@ case_archive_dir: "{{ case_bundle_dir }}/archive"
 case_inventory_name: "{{ lookup('env', 'CASE_INV_NAME') }}"
 
 ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
-
-mirror_dry_run_only: false

--- a/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
@@ -51,32 +51,11 @@
   register: configureCredsResult
 
 
-# 4. Perform a Dry Run
-# -----------------------------------------------------------------------------
-# Perform a dry run first, if it fails it will report why and nothing will be changed om the target system
-- name: "Mirror Images Dry Run ({{ case_bundle_dir }}/case/{{ case_name }})"
-  shell: >
-    cloudctl case launch --action mirror-images \
-      --case {{ case_bundle_dir }}/case/{{ case_name }} \
-      --inventory {{ case_inventory_name }} \
-      --tolerance 1 \
-      --args "--registry {{ registry_public_host }} --inputDir {{ case_archive_dir }} --skipDelta true --dryRun true" \
-    | tee {{ case_bundle_dir }}/mirror-{{ case_name }}-{{ case_inventory_name }}-dryrun.log
-  register: dryrun_result
-  # if USE_SKOPEO flag is set, the command doesn't perform a dry run
-  when: lookup('env', 'USE_SKOPEO') != 'True'
-
-- name: "Debug Dry Run"
-  debug:
-    msg: "{{ dryrun_result.stdout_lines }}"
-
-
-# 5. Execute the Mirror
+# 4. Execute the Mirror
 # -----------------------------------------------------------------------------
 - name: Mirror Images
-  when: not mirror_dry_run_only
   shell: >
-    cloudctl case launch --action mirror-images \
+    export USE_SKOPEO=True && cloudctl case launch --action mirror-images \
       --case {{ case_bundle_dir }}/case/{{ case_name }} \
       --inventory {{ case_inventory_name }} \
       --tolerance 1 \
@@ -88,6 +67,5 @@
   retries: 10
 
 - name: "Debug Mirror"
-  when: not mirror_dry_run_only
   debug:
     msg: "{{ mirror_result.stdout_lines }}"


### PR DESCRIPTION
After discussions with @stonepd re: mirror performance.  The performance increase from using `skopeo` vs `oc mirror` can be as much as 10x ... so change the mirroring to always set the `USE_SKOPEO` environment variable before running.