### PR TITLE
[minor] Add mirror_truststore_mgr playbook

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,6 +22,13 @@ docker run -ti ansible-airgap:local bash
 ```
 
 
+## Ultimate one-liner
+Build the collection, build the docker container, run the docker container ...
+```bash
+ansible-galaxy collection build --output-path image/ansible-airgap/ ibm/mas_airgap --force && mv image/ansible-airgap/ibm-mas_airgap-2.0.0.tar.gz image/ansible-airgap/ibm-mas_airgap.tar.gz && docker build -t ansible-airgap image/ansible-airgap && docker run -ti ansible-airgap bash
+```
+
+
 ## Style Guide
 Failure to adhere to the style guide will result in a PR being rejected!
 

--- a/ibm/mas_airgap/playbooks/mirror_truststore_mgr.yml
+++ b/ibm/mas_airgap/playbooks/mirror_truststore_mgr.yml
@@ -1,0 +1,21 @@
+---
+- hosts: localhost
+  vars:
+    case_name: "ibm-truststore-mgr"
+    case_source: "https://github.com/IBM/cloud-pak/blob/master/repo/case/ibm-truststore-mgr/1.2.2/ibm-sls-1.2.2.tgz?raw=true"
+    case_bundle_dir: /tmp/casebundle-truststore-mgr
+    exclude_images: []
+    case_inventory_name: "ibmTrustStoreMgrSetup"
+    registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
+
+  pre_tasks:
+    # For the full set of supported environment variables refer to the playbook documentation
+    - name: Check for required environment variables
+      assert:
+        that:
+          - lookup('env', 'REGISTRY_PUBLIC_HOST') != ""
+        fail_msg: "One or more required environment variables are not defined"
+
+  roles:
+    - ibm.mas_airgap.case_prepare
+    - ibm.mas_airgap.case_mirror


### PR DESCRIPTION
Delivers a new playbook for mirroring the IBM Truststore Manager images to the private registry.  

- Part of #9 