### PR TITLE
[patch] Various fixes to support one-click airgap setup

### DIFF
--- a/ibm/mas_airgap/playbooks/mirror_common_services.yml
+++ b/ibm/mas_airgap/playbooks/mirror_common_services.yml
@@ -17,7 +17,6 @@
       - ibm-platform-api-operator
       - ibm-zen
     case_inventory_name: "ibmCommonServiceOperatorSetup"
-    registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
 
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
@@ -25,6 +24,7 @@
       assert:
         that:
           - lookup('env', 'REGISTRY_PUBLIC_HOST') != ""
+          - lookup('env', 'REGISTRY_PUBLIC_PORT') != ""
         fail_msg: "One or more required environment variables are not defined"
 
   roles:

--- a/ibm/mas_airgap/playbooks/mirror_mas_core.yml
+++ b/ibm/mas_airgap/playbooks/mirror_mas_core.yml
@@ -16,7 +16,6 @@
       - ibm-mas-mso
       - ibm-sls
     case_inventory_name: "ibmMasSetup"
-    registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
 
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
@@ -24,6 +23,7 @@
       assert:
         that:
           - lookup('env', 'REGISTRY_PUBLIC_HOST') != ""
+          - lookup('env', 'REGISTRY_PUBLIC_PORT') != ""
         fail_msg: "One or more required environment variables are not defined"
 
   roles:

--- a/ibm/mas_airgap/playbooks/mirror_sls.yml
+++ b/ibm/mas_airgap/playbooks/mirror_sls.yml
@@ -6,7 +6,6 @@
     case_bundle_dir: /tmp/casebundle-sls
     exclude_images: []
     case_inventory_name: "ibmSlsSetup"
-    registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
 
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
@@ -14,6 +13,7 @@
       assert:
         that:
           - lookup('env', 'REGISTRY_PUBLIC_HOST') != ""
+          - lookup('env', 'REGISTRY_PUBLIC_PORT') != ""
         fail_msg: "One or more required environment variables are not defined"
 
   roles:

--- a/ibm/mas_airgap/playbooks/mirror_truststore_mgr.yml
+++ b/ibm/mas_airgap/playbooks/mirror_truststore_mgr.yml
@@ -6,7 +6,6 @@
     case_bundle_dir: /tmp/casebundle-truststore-mgr
     exclude_images: []
     case_inventory_name: "ibmTrustStoreMgrSetup"
-    registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
 
   pre_tasks:
     # For the full set of supported environment variables refer to the playbook documentation
@@ -14,6 +13,7 @@
       assert:
         that:
           - lookup('env', 'REGISTRY_PUBLIC_HOST') != ""
+          - lookup('env', 'REGISTRY_PUBLIC_PORT') != ""
         fail_msg: "One or more required environment variables are not defined"
 
   roles:

--- a/ibm/mas_airgap/playbooks/run_role.yml
+++ b/ibm/mas_airgap/playbooks/run_role.yml
@@ -1,0 +1,23 @@
+---
+# This playbook can be used to execute any role in this collection.  It's
+# primary purpose is as the driver for our tekton pipeline Tasks, each
+# task will call ibm.mas_devops.run_role with a specific ROLE_NAME set.
+#
+# This avoids us needing to define an entire swathe of playbooks that
+# are not really playbooks.
+#
+# Individual roles can still be executed normally with Ansible:
+#     ansible localhost -m include_role -a name=ibm.mas_devops.xxx
+#
+# One benefit of using this wrapper is that you will be able to take
+# advantage of Ansible features only available when running a playbook,
+# such as the callbacks that only trigger from a playbook, for example
+# we use the profile_tasks & junit callbacks extensively in our automation
+# frameworks.
+- hosts: localhost
+  any_errors_fatal: true
+  vars:
+    role_name: "{{ lookup('env', 'ROLE_NAME') }}"
+
+  roles:
+    - "ibm.mas_airgap.{{ role_name }}"

--- a/ibm/mas_airgap/roles/case_mirror/defaults/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # Get Registry facts from environment variables if they have not been passed to the role
 registry_public_host: "{{ lookup('env', 'REGISTRY_PUBLIC_HOST') }}"
+registry_public_port: "{{ lookup('env', 'REGISTRY_PUBLIC_PORT') }}"
+registry_public_url: "{{ registry_public_host }}:{{ registry_public_port }}"
 
 # Case config
 case_name: "{{ lookup('env', 'CASE_NAME') }}"

--- a/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
@@ -65,7 +65,7 @@
       --case {{ case_bundle_dir }}/case/{{ case_name }} \
       --inventory {{ case_inventory_name }} \
       --tolerance 1 \
-      --args "--registry {{ registry_public_host }} --inputDir {{ case_archive_dir }} --skipDelta true" \
+      --args "--registry {{ registry_public_url }} --inputDir {{ case_archive_dir }} --skipDelta true" \
     | tee {{ case_bundle_dir }}/mirror-{{ case_name }}-{{ case_inventory_name }}.log
   register: mirror_result
   # This can intermittently fail with "504 Gateway Time-out" errors, retry until sucessful.

--- a/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/main.yml
+++ b/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/main.yml
@@ -26,9 +26,11 @@
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/imagecontentsourcepolicy.yml.j2'
+  register: content_source_policy_result
 
 
 # 4. Wait until the nodes have applied the updates
 # -----------------------------------------------------------------------------
 - name: Wait for Machine Configs to update
+  when: content_source_policy_result.changed
   include_tasks: "tasks/wait-machine-config-update.yml"

--- a/ibm/mas_airgap/roles/registry/README.md
+++ b/ibm/mas_airgap/roles/registry/README.md
@@ -73,7 +73,6 @@ The size of the PVC that will be created for data storage in the cluster.
 ### registry_service_type
 The type of service to set up in front of the registry, either `loadbalancer` or `clusterip`.  Using `loadbalancer` will allow you to access the registry from outside of your cluster via the cluster domain on port `32500`.  If you have other loadbalancers on the cluster that already claim port `32500` this role can not be usedbecause currently the loadbalancer port can not be customised.
 
-
 - Optional
 - Environment Variable: `REGISTRY_SERVICE_TYPE`
 - Default Value: `loadbalancer`

--- a/ibm/mas_airgap/roles/registry/tasks/main.yml
+++ b/ibm/mas_airgap/roles/registry/tasks/main.yml
@@ -30,7 +30,7 @@
     template: 'templates/certs/issuer.yml.j2'
   register: createIssuer
 
-- name: "Create db2u certificate"
+- name: "Create registry certificate"
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/certs/certificate.yml.j2'


### PR DESCRIPTION
These updates align with the work in ibm-mas/installer to provide airgap functionality in the MAS CLI:

- `mas setup-registry` will deploy a private docker registry on an OCP cluster suitable for hosting a mirror of all container images used in a MAS installation
- `mas mirror-images` will mirror all (or a subset) container images needed for a MAS installation to your private registry
- `mas configure-airgap` will configure your target OCP cluster to use a private docker register and will install the operator catalogs required by MAS from that mirror
