### PR TITLE
[minor] Add simulate_network role

### DIFF
--- a/docs/changes.md
+++ b/docs/changes.md
@@ -4,4 +4,5 @@
     - `Add `case_prepare` and `case_mirror` roles ([#3](https://github.com/ibm-mas/ansible-airgap/pull/3))
     - Add `mirror_truststore_mgr` playbook ([#12](https://github.com/ibm-mas/ansible-airgap/pull/12))
     - Support cluster configuration for air gap ([#13](https://github.com/ibm-mas/ansible-airgap/pull/13))
+    - Add `simulate_network` role ([#16](https://github.com/ibm-mas/ansible-airgap/pull/16))
 - `1.0` Initial release ([#2](https://github.com/ibm-mas/ansible-airgap/pull/2))

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,4 +1,7 @@
 ## Changes
 
-- `1.1` Add `case_prepare` and `case_mirror` roles ([#3](https://github.com/ibm-mas/ansible-airgap/pull/3))
+- `1.1` Multiple updates:
+    - `Add `case_prepare` and `case_mirror` roles ([#3](https://github.com/ibm-mas/ansible-airgap/pull/3))
+    - Add `mirror_truststore_mgr` playbook ([#12](https://github.com/ibm-mas/ansible-airgap/pull/12))
+    - Support cluster configuration for air gap ([#13](https://github.com/ibm-mas/ansible-airgap/pull/13))
 - `1.0` Initial release ([#2](https://github.com/ibm-mas/ansible-airgap/pull/2))

--- a/ibm/mas_airgap/README.md
+++ b/ibm/mas_airgap/README.md
@@ -4,5 +4,8 @@
 [https://ibm-mas.github.io/ansible-airgap/](https://ibm-mas.github.io/ansible-airgap/)
 
 ## Change Log
-- `1.1` Add `case_prepare` and `case_mirror` roles ([#3](https://github.com/ibm-mas/ansible-airgap/pull/3))
+- `1.1` Multiple updates:
+    - `Add `case_prepare` and `case_mirror` roles ([#3](https://github.com/ibm-mas/ansible-airgap/pull/3))
+    - Add `mirror_truststore_mgr` playbook ([#12](https://github.com/ibm-mas/ansible-airgap/pull/12))
+    - Support cluster configuration for air gap ([#13](https://github.com/ibm-mas/ansible-airgap/pull/13))
 - `1.0` Initial release ([#2](https://github.com/ibm-mas/ansible-airgap/pull/2))

--- a/ibm/mas_airgap/README.md
+++ b/ibm/mas_airgap/README.md
@@ -8,4 +8,5 @@
     - `Add `case_prepare` and `case_mirror` roles ([#3](https://github.com/ibm-mas/ansible-airgap/pull/3))
     - Add `mirror_truststore_mgr` playbook ([#12](https://github.com/ibm-mas/ansible-airgap/pull/12))
     - Support cluster configuration for air gap ([#13](https://github.com/ibm-mas/ansible-airgap/pull/13))
+    - Add `simulate_network` role ([#16](https://github.com/ibm-mas/ansible-airgap/pull/16))
 - `1.0` Initial release ([#2](https://github.com/ibm-mas/ansible-airgap/pull/2))

--- a/ibm/mas_airgap/roles/simulate_network/README.md
+++ b/ibm/mas_airgap/roles/simulate_network/README.md
@@ -1,0 +1,17 @@
+simulate_network
+================
+
+Our goal is to modify the hosts file on each node (worker and master) to add a bogus entry that breaks DNS resolution for all the registries that we are going to mirror.  This will simulate the cluster running in an air gap configuration, although network access will be possible elsewhere, the cluster will be unable to access the docker registries
+
+!!! important
+    The host file (on Fyre) will look something like this, this role is (for now anyway) mainly focused on simulating an air gap cluster in Fyre, it may work on other cluster providers but that can not be guaranteed and may require modifications depending on the specific way OpenShift is set up.
+
+
+```bash
+oc get nodes
+oc debug node/node1
+sh-4.4# more /host/etc/hosts
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+172.30.55.8 image-registry.openshift-image-registry.svc image-registry.openshift-image-registry.svc.cluster.local # openshift-generated-node-resolver
+```

--- a/ibm/mas_airgap/roles/simulate_network/defaults/main.yml
+++ b/ibm/mas_airgap/roles/simulate_network/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+airgap_network_exclusions: "icr.io cp.icr.io quay.io wiotp-docker-local.artifactory.swg-devops.com"

--- a/ibm/mas_airgap/roles/simulate_network/tasks/main.yml
+++ b/ibm/mas_airgap/roles/simulate_network/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# Disable network access to public image repositories
+# -----------------------------------------------------------------------------
+
+# The hosts file needs to include a line for the registry service, otherwise the
+# file will get out of sync with the version on the file system, and MCO updates will fail.
+- name: Lookup Registry Service
+  community.kubernetes.k8s_info:
+    api_version: v1
+    kind: Service
+    name: image-registry
+    namespace: openshift-image-registry
+  register: registry_service_result
+
+- debug:
+    var: registry_service_result
+
+# Disable Network access to public repositories
+## Set the /etc/hosts file on each cluster node to mis-direct any calls to icr.io, cp.icr.io and wiotp-docker-local.artifactory.swg-devops.com
+- name: Create hosts file
+  vars:
+    hosts_file_content: |
+      127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+      ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+      1.2.3.4     {{ airgap_network_exclusions }}
+      {{ registry_service_result.resources[0].spec.clusterIP }} image-registry.openshift-image-registry.svc image-registry.openshift-image-registry.svc.cluster.local # openshift-generated-node-resolver
+    hosts_file_b64: "{{ hosts_file_content | b64encode }} "
+  community.kubernetes.k8s:
+    apply: yes
+    template: 'templates/mc.yml.j2'
+  register: result
+
+- debug:
+    var: result
+
+# Wait until the nodes have applied the updates
+- name: Wait for Machine Configs to update
+  when: result.changed
+  include_tasks: "tasks/wait-machine-config-update.yml"

--- a/ibm/mas_airgap/roles/simulate_network/tasks/wait-machine-config-update.yml
+++ b/ibm/mas_airgap/roles/simulate_network/tasks/wait-machine-config-update.yml
@@ -1,0 +1,43 @@
+---
+# 1. Wait for node pools to start updating
+# -----------------------------------------------------------------------------
+- name: Wait for node pools to start updating
+  kubernetes.core.k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: "{{ item }}"
+    wait: yes
+    wait_sleep: 5
+    wait_timeout: 15 # give 15 seconds for the machines to start updating, if necessary
+    wait_condition:
+      type: Updating
+      status: 'True'
+  register: _mcp
+  ignore_errors: true
+  loop:
+    - "worker"
+    - "master"
+
+
+# 2. Wait for node pools to finish updating
+# -----------------------------------------------------------------------------
+- name: Wait for node pools to finish updating
+  kubernetes.core.k8s_info:
+    api_version: machineconfiguration.openshift.io/v1
+    kind: MachineConfigPool
+    name: "{{ item }}"
+    wait: yes
+    wait_sleep: 10
+    wait_timeout: 60 # 1 min wait
+    wait_condition:
+      type: Updated
+      status: 'True'
+  register: _mcp
+  retries: 20 #  give approx 20 minutes before we give up waiting for the nodes to update
+  delay: 1
+  until:
+    - _mcp.resources is defined
+    - _mcp.resources | length > 0
+  loop:
+    - "worker"
+    - "master"

--- a/ibm/mas_airgap/roles/simulate_network/templates/mc.yml.j2
+++ b/ibm/mas_airgap/roles/simulate_network/templates/mc.yml.j2
@@ -1,0 +1,51 @@
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 50-workers-etc-hosts-config
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.1.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ hosts_file_b64 }}
+        overwrite: true
+        mode: 420
+        path: /etc/hosts
+  osImageURL: ""
+
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 50-masters-etc-hosts-config
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.1.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,{{ hosts_file_b64 }}
+        overwrite: true
+        mode: 420
+        path: /etc/hosts
+  osImageURL: ""


### PR DESCRIPTION
This role will modify the hosts file on each node (worker and master) to add a bogus entry that breaks DNS resolution for all the registries that we are going to mirror.  This will simulate the cluster running in an air gap configuration, although network access will be possible elsewhere, the cluster will be unable to access the docker registries

After running this, the debug pod can't even be used, which proves that quay.io has been blocked and our simulated airgap networking is working.

```
Starting pod/master0djpairgapcpfyreibmcom-debug ...
To use host binaries, run `chroot /host`
more /host/etc/hosts
warning: Container container-00 is unable to start due to an error: Back-off pulling image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d42e07c9778fb229093b2e746b706cb13977d3b5bff30f788bb1465688e451a3"
warning: Container container-00 is unable to start due to an error: Back-off pulling image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d42e07c9778fb229093b2e746b706cb13977d3b5bff30f788bb1465688e451a3"
warning: Container container-00 is unable to start due to an error: Back-off pulling image "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d42e07c9778fb229093b2e746b706cb13977d3b5bff30f788bb1465688e451a3"
```