### PR TITLE
[patch] Fix MongoDb CE mirroring

### DIFF
--- a/ibm/mas_airgap/roles/simulate_network/defaults/main.yml
+++ b/ibm/mas_airgap/roles/simulate_network/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
-airgap_network_exclusions: "icr.io cp.icr.io quay.io wiotp-docker-local.artifactory.swg-devops.com"
+# Ideally we would add quay.io here as well, but we can't until we mirror all the images used by OCP itself
+airgap_network_exclusions: "icr.io cp.icr.io wiotp-docker-local.artifactory.swg-devops.com"

--- a/ibm/mas_airgap/roles/simulate_network/tasks/main.yml
+++ b/ibm/mas_airgap/roles/simulate_network/tasks/main.yml
@@ -5,7 +5,7 @@
 # The hosts file needs to include a line for the registry service, otherwise the
 # file will get out of sync with the version on the file system, and MCO updates will fail.
 - name: Lookup Registry Service
-  community.kubernetes.k8s_info:
+  kubernetes.core.k8s_info:
     api_version: v1
     kind: Service
     name: image-registry
@@ -25,7 +25,7 @@
       1.2.3.4     {{ airgap_network_exclusions }}
       {{ registry_service_result.resources[0].spec.clusterIP }} image-registry.openshift-image-registry.svc image-registry.openshift-image-registry.svc.cluster.local # openshift-generated-node-resolver
     hosts_file_b64: "{{ hosts_file_content | b64encode }} "
-  community.kubernetes.k8s:
+  kubernetes.core.k8s:
     apply: yes
     template: 'templates/mc.yml.j2'
   register: result

--- a/ibm/mas_airgap/roles/thirdparty_mirror/defaults/main.yml
+++ b/ibm/mas_airgap/roles/thirdparty_mirror/defaults/main.yml
@@ -5,8 +5,22 @@ registry_public_url: "{{ registry_public_host }}:{{ registry_public_port }}"
 
 # These need to be kept in line with the images we actually use
 mongo_mirror_images:
-  - mongodb/mongodb-kubernetes-operator:0.7.0
-  - mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook:1.0.2
-  - mongodb/mongodb-agent:11.0.5.6963-1
-  - mongodb/mongodb-kubernetes-readinessprobe:1.0.4
-  - ibmmas/mongo:4.2.6
+  - name: mongodb/mongodb-kubernetes-operator
+    tag: 0.7.0
+    digest: sha256:e19ae43539521f0350fb71684757dc535fc989deb75f3789cd84b782489eda80
+
+  - name: mongodb/mongodb-kubernetes-operator-version-upgrade-post-start-hook
+    tag: 1.0.2
+    digest: sha256:da347eb74525715a670280545e78ecee1195ec2630037b3821591c87f7a314ee
+
+  - name: mongodb/mongodb-agent
+    tag: 11.0.5.6963-1
+    digest: sha256:4db6e9c7df3d9421dcc09e98c5b43ba9d95952eae3c2ccbfdb83a49743b3195f
+
+  - name: mongodb/mongodb-kubernetes-readinessprobe
+    tag: 1.0.4
+    digest: sha256:bf5a4ffc8d2d257d6d9eb45d3e521f30b2e049a9b60ddc8e4865448e035502ca
+
+  - name: ibmmas/mongo
+    tag: 4.2.6
+    digest: sha256:8c48baa1571469d7f5ae6d603b92b8027ada5eb39826c009cb33a13b46864908

--- a/ibm/mas_airgap/roles/thirdparty_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/thirdparty_mirror/tasks/main.yml
@@ -1,5 +1,9 @@
 ---
 
 - name: "Mirror Mongo CE Operator images to airgap registry"
-  shell: "skopeo copy docker://quay.io/{{ item }} docker://{{ registry_public_url }}/{{ item }}"
+  shell: "skopeo copy --all docker://quay.io/{{ item.name }}@{{ item.digest }} docker://{{ registry_public_url }}/{{ item.name }}:{{ item.tag }}"
   with_items: "{{ mongo_mirror_images }}"
+  register: mirror_result
+
+- debug:
+    var: mirror_result


### PR DESCRIPTION
- Remove quay.io from network exclusions (unless we mirror all the redhat content for OCP we can't do this)
- Update community.kubernetes to kubernetes.core
- Improvements to MongoDb image mirroring