### PR TITLE
[patch] Install missing hostname tool (required by cloudctl)

### DIFF
--- a/ibm/mas_airgap/roles/case_mirror/defaults/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/defaults/main.yml
@@ -11,6 +11,8 @@ case_archive_dir: "{{ case_bundle_dir }}/archive"
 case_inventory_name: "{{ lookup('env', 'CASE_INV_NAME') }}"
 
 ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
+ibm_auth: "cp:{{ ibm_entitlement_key }}"
 
 redhat_connect_username: "{{ lookup('env', 'REDHAT_CONNECT_USERNAME') }}"
 redhat_connect_password: "{{ lookup('env', 'REDHAT_CONNECT_PASSWORD') }}"
+redhat_connect_auth: "{{ redhat_connect_username }}:{{ redhat_connect_password }}"

--- a/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
@@ -51,37 +51,69 @@
   shell: chmod u+x {{ case_bundle_dir }}/case/{{ case_name }}/inventory/{{ case_inventory_name }}/files/*.sh
 
 
-# 5. Set up Authentication for ICR
+# 5. Set up authentication
 # -----------------------------------------------------------------------------
-# TODO: For now this is limited to unauthenticed registry (like the one set up by the "registry" role)
-- name: "Setup ICR Registry Credentials"
-  shell: >
-    cloudctl case launch --action configureCredsAirgap \
-      --case {{ case_bundle_dir }}/case/{{ case_name }} \
-      --inventory {{ case_inventory_name }} \
-      --tolerance 1 \
-      --args '--registry cp.icr.io --user cp --pass {{ ibm_entitlement_key }}'
-  register: configureCredsResult
+- name: Create auth secret (IBM)
+  vars:
+    registry_name: cp.icr.io
+    registry_auth: "{{ ibm_auth }}"
+  ansible.builtin.template:
+    src: templates/auth-secret.json.j2
+    dest: "{{ ansible_env.HOME }}/.airgap/secrets/{{ registry_name }}.json"
 
-# https://access.redhat.com/RegistryAuthentication
-- name: "Setup Red Hat Connect Registry Credentials"
-  when: case_name == "ibm-uds"
-  shell: >
-    cloudctl case launch --action configureCredsAirgap \
-      --case {{ case_bundle_dir }}/case/{{ case_name }} \
-      --inventory {{ case_inventory_name }} \
-      --tolerance 1 \
-      --args '--registry registry.connect.redhat.com --user {{ redhat_connect_username }} --pass {{ redhat_connect_password }}'
-  register: configureCredsResult
-- name: "Setup Red Hat Connect Registry Credentials"
-  when: case_name == "ibm-uds"
-  shell: >
-    cloudctl case launch --action configureCredsAirgap \
-      --case {{ case_bundle_dir }}/case/{{ case_name }} \
-      --inventory {{ case_inventory_name }} \
-      --tolerance 1 \
-      --args '--registry registry.redhat.io --user {{ redhat_connect_username }} --pass {{ redhat_connect_password }}'
-  register: configureCredsResult
+- name: Create auth secret (Red Hat 1/2)
+  when:
+    - redhat_connect_username is defined and redhat_connect_username != ""
+    - redhat_connect_password is defined and redhat_connect_password != ""
+  vars:
+    registry_name: registry.connect.redhat.com
+    registry_auth: "{{ redhat_connect_auth }}"
+  ansible.builtin.template:
+    src: templates/auth-secret.json.j2
+    dest: "{{ ansible_env.HOME }}/.airgap/secrets/{{ registry_name }}.json"
+
+- name: Create auth secret (Red Hat 2/2)
+  when:
+    - redhat_connect_username is defined and redhat_connect_username != ""
+    - redhat_connect_password is defined and redhat_connect_password != ""
+  vars:
+    registry_name: registry.redhat.io
+    registry_auth: "{{ redhat_connect_auth }}"
+  ansible.builtin.template:
+    src: templates/auth-secret.json.j2
+    dest: "{{ ansible_env.HOME }}/.airgap/secrets/{{ registry_name }}.json"
+
+# # 5. Set up Authentication for ICR
+# # -----------------------------------------------------------------------------
+# # TODO: For now this is limited to unauthenticed registry (like the one set up by the "registry" role)
+# - name: "Setup ICR Registry Credentials"
+#   shell: >
+#     cloudctl case launch --action configureCredsAirgap \
+#       --case {{ case_bundle_dir }}/case/{{ case_name }} \
+#       --inventory {{ case_inventory_name }} \
+#       --tolerance 1 \
+#       --args '--registry cp.icr.io --user cp --pass {{ ibm_entitlement_key }}'
+#   register: configureCredsResult
+
+# # https://access.redhat.com/RegistryAuthentication
+# - name: "Setup Red Hat Connect Registry Credentials"
+#   when: case_name == "ibm-uds"
+#   shell: >
+#     cloudctl case launch --action configureCredsAirgap \
+#       --case {{ case_bundle_dir }}/case/{{ case_name }} \
+#       --inventory {{ case_inventory_name }} \
+#       --tolerance 1 \
+#       --args '--registry registry.connect.redhat.com --user {{ redhat_connect_username }} --pass {{ redhat_connect_password }}'
+#   register: configureCredsResult
+# - name: "Setup Red Hat Connect Registry Credentials"
+#   when: case_name == "ibm-uds"
+#   shell: >
+#     cloudctl case launch --action configureCredsAirgap \
+#       --case {{ case_bundle_dir }}/case/{{ case_name }} \
+#       --inventory {{ case_inventory_name }} \
+#       --tolerance 1 \
+#       --args '--registry registry.redhat.io --user {{ redhat_connect_username }} --pass {{ redhat_connect_password }}'
+#   register: configureCredsResult
 
 
 
@@ -98,9 +130,11 @@
       --args "--registry {{ registry_public_url }} --inputDir {{ case_archive_dir }} --skipDelta true" \
     | tee {{ case_bundle_dir }}/mirror-{{ case_name }}-{{ case_inventory_name }}.log
   register: mirror_result
-  # This can intermittently fail with "504 Gateway Time-out" errors, retry until sucessful.
-  until: mirror_result['rc'] == 0 or mirror_result['stdout'] is not search('504 Gateway Time', multiline=True)
-  retries: 10
+
+- name: "Debug Mirror"
+  when: case_name != "ibm-uds"
+  debug:
+    msg: "{{ mirror_result.stdout_lines }}"
 
 - name: Mirror Images (UDS special case)
   when: case_name == "ibm-uds"
@@ -111,10 +145,8 @@
       --args "--registry {{ registry_public_url }} --inputDir {{ case_archive_dir }}" \
     | tee {{ case_bundle_dir }}/mirror-{{ case_name }}-{{ case_inventory_name }}.log
   register: mirror_result
-  # This can intermittently fail with "504 Gateway Time-out" errors, retry until sucessful.
-  until: mirror_result['rc'] == 0 or mirror_result['stdout'] is not search('504 Gateway Time', multiline=True)
-  retries: 10
 
 - name: "Debug Mirror"
+  when: case_name == "ibm-uds"
   debug:
     msg: "{{ mirror_result.stdout_lines }}"

--- a/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/case_mirror/tasks/main.yml
@@ -51,9 +51,20 @@
   shell: chmod u+x {{ case_bundle_dir }}/case/{{ case_name }}/inventory/{{ case_inventory_name }}/files/*.sh
 
 
-# 5. Set up authentication
+# 5. Set up authentication for the case mirroring process
 # -----------------------------------------------------------------------------
-- name: Create auth secret (IBM)
+# This is the ansible equivalent of running:
+#     "cloudctl case launch --action configureCredsAirgap ..."
+# but it's faster, cleaner, and handles special characters in passwords properly
+
+# 5.1 Prepare the directory
+- name: Creates airgap secrets directory
+  file:
+    path: "{{ ansible_env.HOME }}/.airgap/secrets"
+    state: directory
+
+# 5.2 IBM entitled content
+- name: Create auth secret for cp.icr.io
   vars:
     registry_name: cp.icr.io
     registry_auth: "{{ ibm_auth }}"
@@ -61,7 +72,8 @@
     src: templates/auth-secret.json.j2
     dest: "{{ ansible_env.HOME }}/.airgap/secrets/{{ registry_name }}.json"
 
-- name: Create auth secret (Red Hat 1/2)
+# 5.3 Red Hat Registry (1/2)
+- name: Create auth secret for registry.connect.redhat.com
   when:
     - redhat_connect_username is defined and redhat_connect_username != ""
     - redhat_connect_password is defined and redhat_connect_password != ""
@@ -72,7 +84,8 @@
     src: templates/auth-secret.json.j2
     dest: "{{ ansible_env.HOME }}/.airgap/secrets/{{ registry_name }}.json"
 
-- name: Create auth secret (Red Hat 2/2)
+# 5.4 Red Hat Registry (2/2)
+- name: Create auth secret for registry.redhat.io
   when:
     - redhat_connect_username is defined and redhat_connect_username != ""
     - redhat_connect_password is defined and redhat_connect_password != ""
@@ -82,39 +95,6 @@
   ansible.builtin.template:
     src: templates/auth-secret.json.j2
     dest: "{{ ansible_env.HOME }}/.airgap/secrets/{{ registry_name }}.json"
-
-# # 5. Set up Authentication for ICR
-# # -----------------------------------------------------------------------------
-# # TODO: For now this is limited to unauthenticed registry (like the one set up by the "registry" role)
-# - name: "Setup ICR Registry Credentials"
-#   shell: >
-#     cloudctl case launch --action configureCredsAirgap \
-#       --case {{ case_bundle_dir }}/case/{{ case_name }} \
-#       --inventory {{ case_inventory_name }} \
-#       --tolerance 1 \
-#       --args '--registry cp.icr.io --user cp --pass {{ ibm_entitlement_key }}'
-#   register: configureCredsResult
-
-# # https://access.redhat.com/RegistryAuthentication
-# - name: "Setup Red Hat Connect Registry Credentials"
-#   when: case_name == "ibm-uds"
-#   shell: >
-#     cloudctl case launch --action configureCredsAirgap \
-#       --case {{ case_bundle_dir }}/case/{{ case_name }} \
-#       --inventory {{ case_inventory_name }} \
-#       --tolerance 1 \
-#       --args '--registry registry.connect.redhat.com --user {{ redhat_connect_username }} --pass {{ redhat_connect_password }}'
-#   register: configureCredsResult
-# - name: "Setup Red Hat Connect Registry Credentials"
-#   when: case_name == "ibm-uds"
-#   shell: >
-#     cloudctl case launch --action configureCredsAirgap \
-#       --case {{ case_bundle_dir }}/case/{{ case_name }} \
-#       --inventory {{ case_inventory_name }} \
-#       --tolerance 1 \
-#       --args '--registry registry.redhat.io --user {{ redhat_connect_username }} --pass {{ redhat_connect_password }}'
-#   register: configureCredsResult
-
 
 
 # 6. Execute the Mirror
@@ -146,7 +126,7 @@
     | tee {{ case_bundle_dir }}/mirror-{{ case_name }}-{{ case_inventory_name }}.log
   register: mirror_result
 
-- name: "Debug Mirror"
+- name: "Debug Mirror (UDS special case)"
   when: case_name == "ibm-uds"
   debug:
     msg: "{{ mirror_result.stdout_lines }}"

--- a/ibm/mas_airgap/roles/case_mirror/templates/auth-secret.json.j2
+++ b/ibm/mas_airgap/roles/case_mirror/templates/auth-secret.json.j2
@@ -1,0 +1,1 @@
+{"auths":{"{{ registry_name }}":{"email":"unused","auth":"{{ registry_auth | b64encode }}"{% raw %}}}}{% endraw %}

--- a/image/ansible-airgap/Dockerfile
+++ b/image/ansible-airgap/Dockerfile
@@ -2,8 +2,8 @@ FROM quay.io/ibmmas/ansible-devops:10.0.4
 
 USER root
 
-# Install skopeo & cloudctl
-RUN dnf install skopeo -y &&\
+# Install skopeo & cloudctl & hostname (needed by cloudctl)
+RUN dnf install skopeo hostname -y &&\
     wget -q https://github.com/IBM/cloud-pak-cli/releases/download/v3.17.0/cloudctl-linux-amd64.tar.gz &&\
     tar -xvf cloudctl-linux-amd64.tar.gz &&\
     mv cloudctl-linux-amd64 /usr/bin/cloudctl &&\


### PR DESCRIPTION
Spotted cloudctl complaining about `hostname` command missing when running this inside our container image.

This also improves the airgap auth setup, removing the use of casectl and directly setting up the credentials in ansible instead.