### PR TITLE
[patch] Fix support for private registry requiring authentication

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @durera @whitfiea
+* @durera

--- a/ibm/mas_airgap/roles/catalogs/defaults/main.yml
+++ b/ibm/mas_airgap/roles/catalogs/defaults/main.yml
@@ -9,3 +9,4 @@
 
 registry_private_host: "{{ lookup('env', 'REGISTRY_PRIVATE_HOST') }}"
 registry_private_port: "{{ lookup('env', 'REGISTRY_PRIVATE_PORT') }}"
+registry_private_url: "{{ registry_private_host }}:{{ registry_private_port }}"

--- a/ibm/mas_airgap/roles/ocp_contentsourcepolicy/defaults/main.yml
+++ b/ibm/mas_airgap/roles/ocp_contentsourcepolicy/defaults/main.yml
@@ -5,3 +5,7 @@ registry_private_port: "{{ lookup('env', 'REGISTRY_PRIVATE_PORT') }}"
 registry_private_url: "{{ registry_private_host }}:{{ registry_private_port }}"
 
 registry_private_ca_file: "{{ lookup('env', 'REGISTRY_PRIVATE_CA_FILE') }}"
+
+registry_auth_username: "{{ lookup('env', 'REGISTRY_AUTH_USERNAME') }}"
+registry_auth_password: "{{ lookup('env', 'REGISTRY_AUTH_PASSWORD') }}"
+registry_auth: "{{ registry_auth_username }}:{{ registry_auth_password }}"

--- a/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/main.yml
+++ b/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/main.yml
@@ -22,7 +22,7 @@
 
 # 3. Create ImageContentSourcePolicy for MAS & dependencies
 # -----------------------------------------------------------------------------
-- name: Create configmap
+- name: Create ImageContentSourcePolicy
   kubernetes.core.k8s:
     apply: yes
     template: 'templates/imagecontentsourcepolicy.yml.j2'

--- a/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/main.yml
+++ b/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/main.yml
@@ -20,7 +20,16 @@
   include_tasks: "tasks/trust.yml"
 
 
-# 3. Create ImageContentSourcePolicy for MAS & dependencies
+# 3. Update default image pull secret
+# -----------------------------------------------------------------------------
+- name: Update default image pull secret
+  when:
+    - registry_auth_username != ""
+    - registry_auth_password != ""
+  include_tasks: "tasks/update-pull-secret.yml"
+
+
+# 4. Create ImageContentSourcePolicy for MAS & dependencies
 # -----------------------------------------------------------------------------
 - name: Create ImageContentSourcePolicy
   kubernetes.core.k8s:
@@ -29,7 +38,7 @@
   register: content_source_policy_result
 
 
-# 4. Wait until the nodes have applied the updates
+# 5. Wait until the nodes have applied the updates
 # -----------------------------------------------------------------------------
 - name: Wait for Machine Configs to update
   when: content_source_policy_result.changed

--- a/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/update-pull-secret.yml
+++ b/ibm/mas_airgap/roles/ocp_contentsourcepolicy/tasks/update-pull-secret.yml
@@ -1,0 +1,58 @@
+---
+
+
+# 1. Update default cluster image pull secret
+# =============================================================================
+
+# 1.1 Generate the new secret content
+- name: "update-pull-secret : Set new secret content"
+  vars:
+    registryAuthB64: "{{ registry_auth | b64encode }}"
+    content:
+      - "{\"auths\":{\"{{ registry_private_url }}\":{\"username\":\"{{ registry_auth_username }}\",\"password\":\"{{ registry_auth_password }}\",\"email\":\"{{ registry_auth_username }}\",\"auth\":\"{{ registryAuthB64 }}\"}"
+      - "}"
+      - "}"
+  set_fact:
+    new_secret: "{{ content | join('') }}"
+
+# 1.2 Find the existing secret, and we are going to modify it rather than replace
+- name: "update-pull-secret : Retrieve existing pull-secret content"
+  kubernetes.core.k8s_info:
+    api: v1
+    kind: Secret
+    name: pull-secret
+    namespace: openshift-config
+  register: pullsecret
+
+- name: "update-pull-secret : Get the original cred secrets"
+  set_fact:
+    original_secret: "{{ item.data }}"
+  with_items: "{{ pullsecret.resources }}"
+  no_log: true
+
+- name: "update-pull-secret : Get the dockerconfigjson info"
+  set_fact:
+    secret_string: '{{ original_secret[".dockerconfigjson"] | b64decode | from_json }}'
+
+# 1.3 Append our new credentials to the secret
+- name: "update-pull-secret : Combine new secret content"
+  set_fact:
+    new_secret_string: '{{ secret_string | combine( new_secret, recursive=True) }}'
+
+# 1.4. Overwrite the secret
+- name: "update-pull-secret : Update new pull-secret"
+  kubernetes.core.k8s:
+    definition:
+      apiVersion: v1
+      kind: Secret
+      type: kubernetes.io/dockerconfigjson
+      metadata:
+        name: pull-secret
+        namespace: openshift-config
+      data:
+        .dockerconfigjson: "{{ new_secret_string | to_json | b64encode }}"
+  register: secretUpdateResult
+
+- name: "update-pull-secret : Debug change state"
+  debug:
+    msg: "Default Pull Secret Changed ....... {{ secretUpdateResult.changed }}"

--- a/image/ansible-airgap/Dockerfile
+++ b/image/ansible-airgap/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-devops:10.2.0
+FROM quay.io/ibmmas/ansible-devops:10.2.1-pre.master
 
 COPY ibm-mas_airgap.tar.gz ${HOME}/ibm-mas_airgap.tar.gz
 


### PR DESCRIPTION
- Fix support for private registry requiring authentication.  Before this fix, use of a private registry requiring authentication would result in the catalog sources never loading.  The cluster default image pull secret is now updated to add the private mirror registry.
- Update container base image to quay.io/ibmmas/ansible-devops:10.2.1-pre.master