### PR TITLE
[patch] Fix mirroring for Assist, HPU, and Predict

### DIFF
--- a/ibm/mas_airgap/roles/case_prepare/tasks/main.yml
+++ b/ibm/mas_airgap/roles/case_prepare/tasks/main.yml
@@ -75,6 +75,13 @@
     case_dir: "{{ case_bundle_dir }}/case"
   register: _case_unzip
 
+# 4.5 Override prereqs files for selected apps
+- name: "Override prereqs.yaml file for selected apps"
+  when: (case_name == "ibm-mas-assist") or
+        (case_name == "ibm-mas-predict") or
+        (case_name == "ibm-mas-hputilities")
+  include_tasks: "tasks/override-prereqs.yml"
+
 
 # 5. Process CASE to configure image mirroring
 # -----------------------------------------------------------------------------

--- a/ibm/mas_airgap/roles/case_prepare/tasks/override-prereqs.yml
+++ b/ibm/mas_airgap/roles/case_prepare/tasks/override-prereqs.yml
@@ -1,0 +1,7 @@
+---
+# Copy an override for prereqs.yaml for assist, predict, and hputilities
+
+- name: Copy override prereqs file into case bundle
+  copy:
+    src: "templates/prereqs-override.yml.j2"
+    dest: "{{ case_bundle_dir }}/case/{{ case_name }}/prereqs.yaml"

--- a/ibm/mas_airgap/roles/case_prepare/templates/prereqs-override.yml.j2
+++ b/ibm/mas_airgap/roles/case_prepare/templates/prereqs-override.yml.j2
@@ -1,0 +1,50 @@
+prereqs:
+  prereqDefs:
+    k8sDistros:
+      openshift:
+        distribution: openshift
+        semver: '>=1.18'
+    k8sResourceVersions: {}
+    k8sResources: 
+      workerIntelLinux:                 # At least one amd64 node
+        metadata:
+          description: "Cluster has at least one amd64 node"
+        kind: node
+        apiGroup: ""
+        version: v1
+        selector:
+          matchExpressions:
+          - {key: beta.kubernetes.io/arch, operator: In, values: [amd64]}
+          - {key: beta.kubernetes.io/os, operator: In, values: [linux]}
+          - {key: node-role.kubernetes.io/worker, operator: Exists}    
+      restrictedSCC:
+        apiGroup: security.openshift.io
+        kind: SecurityContextConstraints
+        metadata:
+          description: Namespace is using the restricted SecurityContextConstraint
+        name: restricted
+        version: v1
+    client:
+      oc:
+        metadata:
+          description: "Client has oc version 4.4.0 or greater"
+        command: "oc"
+        versionArgs: "version --client"
+        versionRegex: "4.[4-9]*.[0-9]*"
+      cloudctl:
+        metadata:
+          description: "Client has cloudctl version v3.7.x or greater"
+        command: "cloudctl"
+        versionArgs: "version"
+        versionRegex: "Client Version: v3.[7-9]*.*"
+      # checking for the presence of below utilities and not checking for any specifc version
+      openssl:
+        metadata:
+          description: "openssl"
+        command: "which"
+        versionArgs: "openssl"
+      htpasswd:
+        metadata:
+          description: "htpasswd"
+        command: "which"
+        versionArgs: "htpasswd" 


### PR DESCRIPTION
Included a task to replace the prereqs.yaml files in assist, hpu, and predict case folder. 
Tested and working well