### PR TITLE
[patch] Update to 10.4.0 base image

### DIFF
--- a/image/ansible-airgap/Dockerfile
+++ b/image/ansible-airgap/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-devops:10.4.0-pre.master
+FROM quay.io/ibmmas/ansible-devops:10.4.0
 
 COPY ibm-mas_airgap.tar.gz ${HOME}/ibm-mas_airgap.tar.gz
 


### PR DESCRIPTION
Update the ansible-airgap container image to use ansible-devops 10.4.0 as it's base