### PR TITLE
[patch] Remove unused parameters from ocp_operators_mirror

### DIFF
--- a/ibm/mas_airgap/roles/ocp_operators_mirror/README.md
+++ b/ibm/mas_airgap/roles/ocp_operators_mirror/README.md
@@ -1,5 +1,5 @@
-case_mirror
-===========
+ocp_operators_mirror
+====================
 This role uses the specifed Red Hat OpenShift Operator version to mirror the standard OpenShift catalog container images to a mirror registry and configure the cluster to pull images from this mirror.
 
 When mirroring is complete, you can view the content of your registry:
@@ -16,7 +16,7 @@ Requirements
 Role Variables
 --------------
 ### openshift_operators_version
-The version of standard operators to be mirrored.
+The version of the operator catalogs to be mirrored in major.minor format, e.g. `4.8`.
 
 - **Required**
 - Environment Variable: `OPENSHIFT_OPERATORS_VERSION`
@@ -64,14 +64,14 @@ The public port number for the target registry
 - Default: None
 
 ### registry_username
-The username for the target registry
+The username for the target registry, if the target registry requires authentication.
 
 - Optional
 - Environment Variable: `REGISTRY_USERNAME`
 - Default: None
 
 ### registry_password
-The password for the target registry
+The password for the target registry, if the target registry requires authentication.
 
 - Optional
 - Environment Variable: `REGISTRY_PASSWORD`

--- a/ibm/mas_airgap/roles/ocp_operators_mirror/README.md
+++ b/ibm/mas_airgap/roles/ocp_operators_mirror/README.md
@@ -15,16 +15,67 @@ Requirements
 
 Role Variables
 --------------
+### openshift_operators_version
+The version of standard operators to be mirrored.
 
-- `openshift_operators_version` The version of standard operators to be mirrored.
-- `log_dir` The directory to write output log.
-- `ibm_entitlement_key` The entitlement key for mirroring container images from cp.icr.io.
-- `redhat_connect_username` The username for accessing Red Hat docker images.
-- `redhat_connect_password` The password for accessing Red Hat docker images.
-- `registry_public_host` The public hostname for the target registry (defaults to the value of the REGISTRY_PUBLIC_HOST environment variable).
-- `registry_public_port` The public port number for the target registry (defaults to the value of the REGISTRY_PUBLIC_PORT environment variable).
-- `registry_username` The username for the target registry (defaults to the value of the REGISTRY_USERNAME environment variable).
-- `registry_password` The password for the target registry (defaults to the value of the REGISTRY_PASSWORD environment variable).
+- **Required**
+- Environment Variable: `OPENSHIFT_OPERATORS_VERSION`
+- Default: None
+
+### log_dir
+The directory to write output log.
+
+- **Required**
+- Environment Variable: `LOG_DIR`
+- Default: `/tmp`
+
+
+Role Variables - Red Hat Authentication
+---------------------------------------
+### redhat_connect_username
+The username for accessing Red Hat docker images.
+
+- **Required**
+- Environment Variable: `REDHAT_CONNECT_USERNAME`
+- Default: None
+
+### redhat_connect_password
+The password for accessing Red Hat docker images.
+
+- **Required**
+- Environment Variable: `REDHAT_CONNECT_PASSWORD`
+- Default: None
+
+
+Role Variables - Target Registry
+--------------------------------
+### registry_public_host
+The public hostname for the target registry
+
+- **Required**
+- Environment Variable: `REGISTRY_PUBLIC_HOST`
+- Default: None
+
+### registry_public_port
+The public port number for the target registry
+
+- **Required**
+- Environment Variable: `REGISTRY_PUBLIC_PORT`
+- Default: None
+
+### registry_username
+The username for the target registry
+
+- Optional
+- Environment Variable: `REGISTRY_USERNAME`
+- Default: None
+
+### registry_password
+The password for the target registry
+
+- Optional
+- Environment Variable: `REGISTRY_PASSWORD`
+- Default: None
 
 
 Example Playbook

--- a/ibm/mas_airgap/roles/ocp_operators_mirror/defaults/main.yml
+++ b/ibm/mas_airgap/roles/ocp_operators_mirror/defaults/main.yml
@@ -6,20 +6,12 @@ registry_public_url: "{{ registry_public_host }}:{{ registry_public_port }}"
 
 # Release config
 openshift_operators_version: "{{ lookup('env', 'OPENSHIFT_OPERATORS_VERSION') }}"
-log_dir: "{{ lookup('env', 'LOG_DIR') }}"
-
-ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
-ibm_auth: "cp:{{ ibm_entitlement_key }}"
+log_dir: "{{ lookup('env', 'LOG_DIR') | default('/tmp', true) }}"
 
 redhat_connect_username: "{{ lookup('env', 'REDHAT_CONNECT_USERNAME') }}"
 redhat_connect_password: "{{ lookup('env', 'REDHAT_CONNECT_PASSWORD') }}"
 redhat_connect_auth: "{{ redhat_connect_username }}:{{ redhat_connect_password }}"
 
-quay_username: "{{ lookup('env', 'QUAY_USERNAME') }}"
-quay_password: "{{ lookup('env', 'QUAY_PASSWORD') }}"
-quay_auth: "{{ quay_username }}:{{ quay_password }}"
-
 registry_username: "{{ lookup('env', 'REGISTRY_USERNAME') }}"
 registry_password: "{{ lookup('env', 'REGISTRY_PASSWORD') }}"
 registry_auth: "{{ registry_username }}:{{ registry_password }}"
-

--- a/ibm/mas_airgap/roles/ocp_operators_mirror/meta/main.yml
+++ b/ibm/mas_airgap/roles/ocp_operators_mirror/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author:
-    - Paul Stone
+    - Rick Acree
     - David Parker
   description: Mirror images to a local registry for AirGap installation
   company: IBM

--- a/ibm/mas_airgap/roles/ocp_operators_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/ocp_operators_mirror/tasks/main.yml
@@ -8,7 +8,6 @@
       - openshift_operators_version is defined and openshift_operators_version != ""
       - log_dir is defined and log_dir != ""
       - registry_public_host is defined and registry_public_host != ""
-      - ibm_entitlement_key is defined and ibm_entitlement_key != ""
       - redhat_connect_username is defined and redhat_connect_username != ""
       - redhat_connect_password is defined and redhat_connect_password != ""
     fail_msg: "One or more required properties are missing"
@@ -32,7 +31,7 @@
 - name: "Airgap setup configuration"
   debug:
     msg:
-      - "OpenShift Operators Version .............. {{ openshift_operators_version }}"
+      - "OpenShift Operators Version ............ {{ openshift_operators_version }}"
       - "Log Directory .......................... {{ log_dir }}"
       - "Registry Public Host ................... {{ registry_public_host }}"
       - "Registry Public Port ................... {{ registry_public_port }}"
@@ -42,14 +41,10 @@
       - "redhat_connect_password ................ {{ redhat_connect_password }}"
       - "registry_name1: {{ registry_public_url }}"
       - "registry_auth1: {{ registry_auth }}"
-      - "registry_name2: cp.icr.io"
-      - "registry_auth2: {{ ibm_auth }}"
-      - "registry_name3: registry.connect.redhat.com"
+      - "registry_name2: registry.connect.redhat.com"
+      - "registry_auth2: {{ redhat_connect_auth }}"
+      - "registry_name3: registry.redhat.io"
       - "registry_auth3: {{ redhat_connect_auth }}"
-      - "registry_name4: registry.redhat.io"
-      - "registry_auth4: {{ redhat_connect_auth }}"
-      - "registry_name5: quay.io"
-      - "registry_auth5: {{ quay_auth }}"
 
 # 4. Set up authentication for the mirroring process
 # -----------------------------------------------------------------------------
@@ -65,14 +60,10 @@
   vars:
     registry_name1: "{{ registry_public_url }}"
     registry_auth1: "{{ registry_auth }}"
-    registry_name2: cp.icr.io
-    registry_auth2: "{{ ibm_auth }}"
-    registry_name3: registry.connect.redhat.com
+    registry_name2: registry.connect.redhat.com
+    registry_auth2: "{{ redhat_connect_auth }}"
+    registry_name3: registry.redhat.io
     registry_auth3: "{{ redhat_connect_auth }}"
-    registry_name4: registry.redhat.io
-    registry_auth4: "{{ redhat_connect_auth }}"
-    registry_name5: quay.io
-    registry_auth5: "{{ quay_auth }}"
   ansible.builtin.template:
     src: templates/auth-file.json.j2
     dest: "{{ ansible_env.HOME }}/.airgap/auth/auth.json"

--- a/ibm/mas_airgap/roles/ocp_operators_mirror/tasks/main.yml
+++ b/ibm/mas_airgap/roles/ocp_operators_mirror/tasks/main.yml
@@ -69,7 +69,7 @@
     dest: "{{ ansible_env.HOME }}/.airgap/auth/auth.json"
 
 
-# 5. Execute the Mirror
+# 5.  Mirror RedHat Operator Images
 # -----------------------------------------------------------------------------
 - name: Mirror RedHat Operator Images (This may take several minutes)
   shell: >
@@ -82,7 +82,7 @@
     msg: "{{ mirror_result.stdout_lines }}"
 
 
-# 6. Execute the Mirror
+# 6.Mirror Community Operator Images
 # -----------------------------------------------------------------------------
 - name: Mirror Community Operator Images (This may take several minutes)
   shell: >
@@ -94,7 +94,7 @@
   debug:
     msg: "{{ mirror_result.stdout_lines }}"
 
-# 7. Execute the Mirror
+# 7. Mirror Certified Operator Images
 # -----------------------------------------------------------------------------
 - name: Mirror Certified Operator Images (This may take several minutes)
   shell: >
@@ -106,7 +106,7 @@
   debug:
     msg: "{{ mirror_result.stdout_lines }}"
 
-# 8. Execute the Mirror
+# 8. Mirror RedHat Marketplace Images
 # -----------------------------------------------------------------------------
 - name: Mirror RedHat Marketplace Images (This may take several minutes)
   shell: >
@@ -117,4 +117,3 @@
 - name: "Debug Mirror"
   debug:
     msg: "{{ mirror_result.stdout_lines }}"
-

--- a/ibm/mas_airgap/roles/ocp_operators_mirror/templates/auth-file.json.j2
+++ b/ibm/mas_airgap/roles/ocp_operators_mirror/templates/auth-file.json.j2
@@ -2,9 +2,7 @@
    {
       "{{ registry_name1 }}": { "auth": "{{ registry_auth1 | b64encode }}" },
       "{{ registry_name2 }}": { "auth": "{{ registry_auth2 | b64encode }}" },
-      "{{ registry_name3 }}": { "auth": "{{ registry_auth3 | b64encode }}" },
-      "{{ registry_name4 }}": { "auth": "{{ registry_auth4 | b64encode }}" },
-      "{{ registry_name5 }}": { "auth": "{{ registry_auth5 | b64encode }}"{% raw %}}
+      "{{ registry_name3 }}": { "auth": "{{ registry_auth3 | b64encode }}"{% raw %}}
   }
 }
 {% endraw %}

--- a/ibm/mas_airgap/roles/ocp_release_mirror/defaults/main.yml
+++ b/ibm/mas_airgap/roles/ocp_release_mirror/defaults/main.yml
@@ -6,7 +6,7 @@ registry_public_url: "{{ registry_public_host }}:{{ registry_public_port }}"
 
 # Release config
 openshift_release_version: "{{ lookup('env', 'OPENSHIFT_RELEASE_VERSION') }}"
-log_dir: "{{ lookup('env', 'LOG_DIR') }}"
+log_dir: "{{ lookup('env', 'LOG_DIR') | default('/tmp', true)  }}"
 
 ibm_entitlement_key: "{{ lookup('env', 'IBM_ENTITLEMENT_KEY') }}"
 ibm_auth: "cp:{{ ibm_entitlement_key }}"

--- a/ibm/mas_airgap/roles/ocp_release_mirror/meta/main.yml
+++ b/ibm/mas_airgap/roles/ocp_release_mirror/meta/main.yml
@@ -1,6 +1,6 @@
 galaxy_info:
   author:
-    - Paul Stone
+    - Rick Acree
     - David Parker
   description: Mirror images to a local registry for AirGap installation
   company: IBM

--- a/image/ansible-airgap/Dockerfile
+++ b/image/ansible-airgap/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/ibmmas/ansible-devops:10.4.0
+FROM quay.io/ibmmas/ansible-devops:10.4.1
 
 COPY ibm-mas_airgap.tar.gz ${HOME}/ibm-mas_airgap.tar.gz
 


### PR DESCRIPTION
- Remove unused IBM Container Registry and quay.io credentials, all images mirrored in this role come from `registry.redhat.io` so we only need the user's Red Hat Connect authentication information.
- Also update the docs to have proper env vars format