### PR TITLE
[patch] Add IoT and Db2u catalog sources

### DIFF
--- a/ibm/mas_airgap/roles/catalogs/templates/ibm-catalogs.yml.j2
+++ b/ibm/mas_airgap/roles/catalogs/templates/ibm-catalogs.yml.j2
@@ -24,6 +24,17 @@ spec:
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
+  name: ibm-mas-iot-operators
+  namespace: openshift-marketplace
+spec:
+  displayName: IBM MAS Operators - IoT
+  image: {{ registry_private_host }}:{{ registry_private_port }}/cpopen/ibm-mas-iot-operator-catalog:latest
+  publisher: IBM
+  sourceType: grpc
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
   name: ibm-sls-operators
   namespace: openshift-marketplace
 spec:
@@ -51,5 +62,16 @@ metadata:
 spec:
   displayName: ibm-udsoperator-catalog
   image: {{ registry_private_host }}:{{ registry_private_port }}/cpopen/ibm-user-data-services-catalog:2.0.7
+  publisher: IBM
+  sourceType: grpc
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: ibm-db2uoperator-catalog
+  namespace: openshift-marketplace
+spec:
+  displayName: ibm-db2uoperator-catalog
+  image: {{ registry_private_host }}:{{ registry_private_port }}/cpopen/ibm-db2uoperator-catalog:latest
   publisher: IBM
   sourceType: grpc


### PR DESCRIPTION
To expand airgap support to the IoT application we must first enable these two new catalogs when setting up the cluster for an airgap/private registry installation:
- `cpopen/ibm-mas-iot-operator-catalog`
- `cpopen/ibm-db2uoperator-catalog`