### PR TITLE
[patch] Add "latest" tag for ibmmas/ansible-airgap

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -52,12 +52,13 @@ jobs:
           $GITHUB_WORKSPACE/build/bin/docker-build.sh -n ibmmas -i ansible-airgap
           docker tag ibmmas/ansible-airgap ibmmas/ansible-airgap:${{ env.DOCKER_TAG }}
           docker tag ibmmas/ansible-airgap quay.io/ibmmas/ansible-airgap:${{ env.DOCKER_TAG }}
+          docker tag ibmmas/ansible-airgap quay.io/ibmmas/ansible-airgap:latest
 
       # https://github.com/marketplace/actions/push-to-registry
       - name: Push the docker image
         id: push_to_quay
         uses: redhat-actions/push-to-registry@v2
         with:
-          tags: quay.io/ibmmas/ansible-airgap:${{ env.DOCKER_TAG }}
+          tags: quay.io/ibmmas/ansible-airgap:${{ env.DOCKER_TAG }} quay.io/ibmmas/ansible-airgap:latest
           username: ${{ secrets.QUAYIO_USERNAME }}
           password: ${{ secrets.QUAYIO_PASSWORD }}

--- a/image/ansible-airgap/Dockerfile
+++ b/image/ansible-airgap/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/ibmmas/ansible-devops:10.6.0
+# Always build from the latest available ansible-devops image
+FROM quay.io/ibmmas/ansible-devops:latest
 
 COPY ibm-mas_airgap.tar.gz ${HOME}/ibm-mas_airgap.tar.gz
 


### PR DESCRIPTION
We have added support for a latest tag to ibmmas/ansible-devops, this update does the same for ansible-airgap.

We also change the Dockerfile to use `ibmmas/ansible-devops:latest` so that we always build this collection's image on top of the latest devops one.  There may be situations in the future where we specifically want to build on an older base image, but I can't think what they would be right now and this makes maintaining the docker images far less error prone as we are not reliant on a developer to manually rev the version.