### PR TITLE
[patch] Remove artifactory from network exclusions

### DIFF
--- a/ibm/mas_airgap/roles/simulate_network/defaults/main.yml
+++ b/ibm/mas_airgap/roles/simulate_network/defaults/main.yml
@@ -1,3 +1,5 @@
 ---
 # Ideally we would add quay.io here as well, but we can't until we mirror all the images used by OCP itself
-airgap_network_exclusions: "icr.io cp.icr.io wiotp-docker-local.artifactory.swg-devops.com"
+# removed artifactory from blocked list while fixing tecton cert issue
+# airgap_network_exclusions: "icr.io cp.icr.io wiotp-docker-local.artifactory.swg-devops.com"
+airgap_network_exclusions: "icr.io cp.icr.io"


### PR DESCRIPTION
- [x] Tested in pipeline ran in `007fvtairgap1` cluster in Fyre. Test evidence:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/15021471/179863751-c297050e-94a9-4421-8eb4-83fe3a7c469e.png">
