### PR TITLE
[patch] Fix ibm.mas_devops dependency range

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,8 +7,8 @@
 build:
 	ansible-galaxy collection build --output-path . ibm/mas_airgap --force
 install:
-	ansible-galaxy collection install ibm-mas_airgap-2.0.0.tar.gz --force --no-deps
+	ansible-galaxy collection install ibm-mas_airgap-3.0.0.tar.gz --force --no-deps
 clean:
-	rm ibm-mas_airgap-2.0.0.tar.gz
+	rm ibm-mas_airgap-3.0.0.tar.gz
 
 all: build install

--- a/docs/changes.md
+++ b/docs/changes.md
@@ -1,5 +1,6 @@
 ## Changes
 
+- `2.0` Support for MAS 8.8 & Maximo Curated Operator Catalog ([#63](https://github.com/ibm-mas/ansible-airgap/pull/63))
 - `1.3` Support IoT application install ([#43](https://github.com/ibm-mas/ansible-airgap/pull/43))
 - `1.2` Multiple updates:
     - Additional mirror playbooks ([#26](https://github.com/ibm-mas/ansible-airgap/pull/26))

--- a/ibm/mas_airgap/README.md
+++ b/ibm/mas_airgap/README.md
@@ -4,6 +4,7 @@
 [https://ibm-mas.github.io/ansible-airgap/](https://ibm-mas.github.io/ansible-airgap/)
 
 ## Change Log
+- `2.0` Support for MAS 8.8 & Maximo Curated Operator Catalog ([#63](https://github.com/ibm-mas/ansible-airgap/pull/63))
 - `1.3` Support IoT application install ([#43](https://github.com/ibm-mas/ansible-airgap/pull/43))
 - `1.2` Multiple updates:
     - Additional mirror playbooks ([#26](https://github.com/ibm-mas/ansible-airgap/pull/26))

--- a/ibm/mas_airgap/galaxy.yml
+++ b/ibm/mas_airgap/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ibm
 name: mas_airgap
-version: 2.0.0
+version: 3.0.0
 readme: README.md
 authors:
   - Paul Stone <stonepd@uk.ibm.com>
@@ -13,7 +13,7 @@ tags:
   - mas
   - rhocp
 dependencies:
-  "ibm.mas_devops": ">=10.0.0,<11.0.0"
+  "ibm.mas_devops": ">=11.0.0,<12.0.0"
 repository: https://github.com/ibm-mas/ansible-airgap/
 documentation: https://ibm-mas.github.io/ansible-airgap/
 homepage: https://ibm-mas.github.io/ansible-airgap/


### PR DESCRIPTION
The dependency range for `ibm.mas_devops` needed to be updated from v10.x.y to v11.x.y for the v2 release of `ibm.mas_airgap`.