### PR TITLE
[patch] Workaround for Manage 8.4.0 bug

### DIFF
--- a/ibm/mas_airgap/roles/install_digest_cm/tasks/main.yml
+++ b/ibm/mas_airgap/roles/install_digest_cm/tasks/main.yml
@@ -17,6 +17,14 @@
     digest_image_map_name: "{{ case_name }}-image-map"
     digest_image_map_file: "{{ role_path }}/../../common_vars/digests/{{ case_name }}/{{ case_version }}.yaml"
 
+# Manage operator v8.4.0 references the wrong config map name
+- name: "Workaround for bug in ibm-mas-manage v8.4.0"
+  when:
+    - case_name == "ibm-mas-manage"
+    - case_version == "8.4.0"
+  set_fact:
+    digest_image_map_name: "ibm-manage-image-map"
+
 - name: "Debug Image Digest Config Map"
   debug:
     msg:


### PR DESCRIPTION
Image Digest Maps should be in the format `{packageId}-image-map`.  Manage v8.4.0 looks for a configmap named `ibm-manage-image-map` instead of `ibm-mas-manage-image-map`, so we need a special case for this version that will adjust the name of the configmap that is created.