### PR TITLE
[patch] Integrate OWASP dependency check

### DIFF
--- a/.github/workflows/ansible-publish.yml
+++ b/.github/workflows/ansible-publish.yml
@@ -42,3 +42,21 @@ jobs:
       - name: Publish Collection
         run: |
           ansible-galaxy collection publish ${{ github.workspace }}/ibm/mas_airgap/ibm-mas_airgap-${{ env.VERSION }}.tar.gz --token=${{ secrets.ANSIBLE_GALAXY_TOKEN }}
+
+      - name: Perform dependency check
+        uses: dependency-check/Dependency-Check_Action@main
+        id: owasp-depcheck
+        with:
+          project: 'ansible-airgap'
+          path: '.'
+          format: 'HTML'
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+
+      - name: Upload dependency check results
+        uses: actions/upload-artifact@v2
+        with:
+           name: OWASP dependency check report
+           path: ${{github.workspace}}/reports
+           retention-days: 90

--- a/.github/workflows/ansible.yml
+++ b/.github/workflows/ansible.yml
@@ -38,3 +38,21 @@ jobs:
           name: ibm-mas_airgap-${{ env.VERSION }}.tar.gz
           path: ${{ github.workspace }}/ibm/mas_airgap/ibm-mas_airgap-${{ env.VERSION }}.tar.gz
           retention-days: 30
+
+      - name: Perform dependency check
+        uses: dependency-check/Dependency-Check_Action@main
+        id: owasp-depcheck
+        with:
+          project: 'ansible-airgap'
+          path: '.'
+          format: 'HTML'
+          args: >
+            --failOnCVSS 7
+            --enableRetired
+
+      - name: Upload dependency check results
+        uses: actions/upload-artifact@v2
+        with:
+           name: OWASP dependency check report
+           path: ${{github.workspace}}/reports
+           retention-days: 30


### PR DESCRIPTION
We're being asked to run [OWASP dependency checker](https://owasp.org/www-project-dependency-check/) against our open source repositories.  It doesn't seem to do much for Ansible, but it ticks another box in a spreadsheet somewhere that we are running it anyway :)

We are running the GitHub Action available here: https://github.com/dependency-check/Dependency-Check_Action